### PR TITLE
added npm run devw for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ The server will run on [localhost:4000](http://localhost:4000).
 $ npm run dev
 ```
 
+or
+
+``` bash
+$ npm run devw
+```
+
+on Windows
+
+
 **Build source files**
 
 Compiles JavaScript files with JavaScript and extracts CSS files from JavaScript.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack --stats --progress",
-    "dev": "cross-env NODE_ENV=development webpack --watch --config webpack/server.js & cross-env NODE_ENV=development node index",
+    "dev": "NODE_ENV=development webpack --watch --config webpack/server.js & NODE_ENV=development node index",
+    "devw": "start cross-env NODE_ENV=development webpack --watch --config webpack/server.js & start cross-env NODE_ENV=development node index",
     "eslint": "eslint ./src --ext .js,.jsx",
     "jscs": "jscs .",
     "start": "cross-env NODE_ENV=production node index"
@@ -35,6 +36,7 @@
     "nodeify": "^1.0.0",
     "normalize.css": "^3.0.3",
     "react": "^0.14.0",
+    "react-addons-css-transition-group": "^15.1.0",
     "react-dom": "^0.14.0",
     "react-dropzone": "^3.1.0",
     "react-facebook-login": "^2.0.5",


### PR DESCRIPTION
I had to add a new command for Windows Systems... To launch multiple and concurrent commands on windows you need the start command at the beginning.

I also took the right to add "react-addons-css-transition-group" because without it I was getting errors
